### PR TITLE
feat: callable class cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    standard-hexarad (1.0.1)
+    standard-hexarad (2.0.0)
       lint_roller
       rubocop
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -4,3 +4,5 @@ Hexarad/ExcessModuleName:
     - FactoryBot
   Include:
     - "spec/**/*_spec.rb"
+Hexarad/CallableClass:
+  Enabled: true

--- a/lib/standard/hexarad.rb
+++ b/lib/standard/hexarad.rb
@@ -7,6 +7,8 @@ module Standard
   end
 end
 
+require "rubocop"
 require_relative "hexarad/cop/excess_module_name"
+require_relative "hexarad/cop/callable_class"
 require_relative "hexarad/version"
 require_relative "hexarad/plugin"

--- a/lib/standard/hexarad/cop/callable_class.rb
+++ b/lib/standard/hexarad/cop/callable_class.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop::Cop
+  module Hexarad
+    class CallableClass < RuboCop::Cop::Base
+      extend RuboCop::Cop::AutoCorrector
+      include RangeHelp
+
+      MSG = "Callable class usage for %<class_name>s"
+      def_node_matcher :callable_class, <<~PATTERN
+        (send $(send _ :new) :call ...)
+      PATTERN
+
+      def on_send(node)
+        callable_class(node) do |expr|
+          class_name = "Todo"
+          add_offense(node, message: format(MSG, class_name:)) do |corrector|
+            corrector.remove(
+              range_between(
+                expr.loc.expression.end_pos - 4,
+                expr.loc.expression.end_pos
+              )
+            )
+          end
+        end
+      end
+
+      private
+
+      def ignore_classes = Array(cop_config["IgnoreClasses"])
+    end
+  end
+end

--- a/lib/standard/hexarad/cop/excess_module_name.rb
+++ b/lib/standard/hexarad/cop/excess_module_name.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rubocop"
-
 module RuboCop::Cop
   module Hexarad
     class ExcessModuleName < RuboCop::Cop::Base

--- a/lib/standard/hexarad/version.rb
+++ b/lib/standard/hexarad/version.rb
@@ -2,6 +2,6 @@
 
 module Standard
   module Hexarad
-    VERSION = "1.0.1"
+    VERSION = "2.0.0"
   end
 end

--- a/spec/standard/cop/callable_class_spec.rb
+++ b/spec/standard/cop/callable_class_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe RuboCop::Cop::Hexarad::CallableClass do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new("Hexarad/CallableClass" => {
+      "Enabled" => true,
+      "IgnoreClasses" => ["AllowMe"]
+    })
+  end
+
+  it "finds violation to callable style" do
+    expect_offense <<-RUBY
+      MyClass.new.call
+      ^^^^^^^^^^^^^^^^ Callable class usage for Todo
+    RUBY
+
+    expect_correction <<-RUBY
+      MyClass.call
+    RUBY
+  end
+
+  it "finds violation to callable style when call has args" do
+    expect_offense <<-RUBY
+      MyClass.new.call(thing: "arg")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callable class usage for Todo
+    RUBY
+
+    expect_correction <<-RUBY
+      MyClass.call(thing: "arg")
+    RUBY
+  end
+end

--- a/spec/standard/cop/callable_class_spec.rb
+++ b/spec/standard/cop/callable_class_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Hexarad::CallableClass do
   it "finds violation to callable style" do
     expect_offense <<-RUBY
       MyClass.new.call
-      ^^^^^^^^^^^^^^^^ Callable class usage for Todo
+      ^^^^^^^^^^^^^^^^ Callable class usage for MyClass
     RUBY
 
     expect_correction <<-RUBY
@@ -19,10 +19,27 @@ RSpec.describe RuboCop::Cop::Hexarad::CallableClass do
     RUBY
   end
 
+  it "ignored violation to callable style when on ignored class" do
+    expect_no_offenses <<-RUBY
+      AllowMe.new.call
+    RUBY
+  end
+
   it "finds violation to callable style when call has args" do
     expect_offense <<-RUBY
       MyClass.new.call(thing: "arg")
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callable class usage for Todo
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callable class usage for MyClass
+    RUBY
+
+    expect_correction <<-RUBY
+      MyClass.call(thing: "arg")
+    RUBY
+  end
+
+  it "finds violation to callable style when new has args" do
+    expect_offense <<-RUBY
+      MyClass.new(thing: "arg").call
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callable class usage for MyClass
     RUBY
 
     expect_correction <<-RUBY


### PR DESCRIPTION
Adds a new Cop the detect inconsistent callable class syntax.

```ruby
# bad
MyClass.new.call

# good
MyClass.call
```